### PR TITLE
Feat/fetch-binary-guard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-getweb"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 description = "A Model Context Protocol server for web search using DuckDuckGo, Google Search, and Felo AI"
 license = "MIT"

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,8 @@ fn print_box(lines: &[&str]) {
                 let left_padding = total_padding / 2;
                 let right_padding = total_padding - left_padding;
 
-                eprintln!("║  {}{}{}\x1b[36m║",
+                eprintln!(
+                    "║  {}{}{}\x1b[36m║",
                     " ".repeat(left_padding),
                     line,
                     " ".repeat(right_padding)
@@ -83,7 +84,7 @@ async fn main() {
             - fetch-url: Fetch and extract content from a URL\n\
             - url-metadata: Extract metadata from a URL\n\
             - url-fetch: Fetch web pages and convert them to markdown\n\
-            - felo-search: Search using Felo AI for AI-generated responses"
+            - felo-search: Search using Felo AI for AI-generated responses",
         )
         .arg(
             Arg::new("google-api-key")
@@ -197,7 +198,7 @@ async fn main() {
             "\x1b[0m Model Context Protocol server for web search \x1b[0m",
             "",
             "\x1b[90m https://github.com/ivan-mezentsev/mcp-getweb \x1b[0m",
-            ""
+            "",
         ]);
     }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use tracing::{info, debug, warn};
+use tracing::{debug, info, warn};
 
 use super::transport::StdioTransport;
 use super::types::*;
@@ -41,17 +41,15 @@ impl McpServer {
 
         loop {
             match self.transport.read_message().await? {
-                Some(message) => {
-                    match message {
-                        McpMessage::Request(request) => {
-                            let response = self.handle_request(request).await;
-                            self.transport.write_response(response).await?;
-                        }
-                        McpMessage::Notification(notification) => {
-                            self.handle_notification(notification).await;
-                        }
+                Some(message) => match message {
+                    McpMessage::Request(request) => {
+                        let response = self.handle_request(request).await;
+                        self.transport.write_response(response).await?;
                     }
-                }
+                    McpMessage::Notification(notification) => {
+                        self.handle_notification(notification).await;
+                    }
+                },
                 None => {
                     info!("Client disconnected");
                     break;

--- a/src/mcp/transport.rs
+++ b/src/mcp/transport.rs
@@ -5,7 +5,7 @@ use tokio::io::BufReader;
 use tokio_util::codec::{FramedRead, FramedWrite, LinesCodec};
 use tracing::{debug, error};
 
-use super::types::{McpMessage, McpRequest, McpResponse, McpNotification};
+use super::types::{McpMessage, McpNotification, McpRequest, McpResponse};
 
 pub struct StdioTransport {
     reader: FramedRead<BufReader<tokio::io::Stdin>, LinesCodec>,
@@ -45,7 +45,9 @@ impl StdioTransport {
                             } else {
                                 // This is a notification
                                 match serde_json::from_value::<McpNotification>(value) {
-                                    Ok(notification) => Ok(Some(McpMessage::Notification(notification))),
+                                    Ok(notification) => {
+                                        Ok(Some(McpMessage::Notification(notification)))
+                                    }
                                     Err(e) => {
                                         error!("Failed to parse notification: {}", e);
                                         Err(anyhow::anyhow!("Invalid JSON-RPC notification: {}", e))

--- a/src/tools/fetch_url_tool.rs
+++ b/src/tools/fetch_url_tool.rs
@@ -1,10 +1,10 @@
 use once_cell::sync::Lazy;
 use serde::Deserialize;
 use serde_json::json;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::mcp::types::{CallToolResult, ToolAnnotations, ToolDefinition};
-use crate::utils::content_guard::safe_truncate_utf8;
+use crate::utils::content_guard::{build_error_payload, safe_truncate_utf8};
 use crate::utils::duckduckgo_search::{fetch_url_content, ContentExtractionOptions};
 
 pub static FETCH_URL_TOOL_DEFINITION: Lazy<ToolDefinition> = Lazy::new(|| ToolDefinition {
@@ -164,9 +164,26 @@ impl FetchUrlTool {
                 CallToolResult::success(format!("{}{}", truncated_content, metadata))
             }
             Err(e) => {
-                error!("Error fetching URL {}: {}", params.url, e);
-                // Propagate the error string as-is without altering the format
-                CallToolResult::error(e.to_string())
+                let err_str = e.to_string();
+                // Detect standardized binary refusal payload by its first line
+                let first_line = err_str.lines().next().unwrap_or("");
+                if first_line == "Fetch cannot be performed for this type of content" {
+                    // Binary content refusal — log WARN and pass-through as-is
+                    warn!("Refused fetch due to unsupported binary content (policy=binary-guard) for URL {}", params.url);
+                    CallToolResult::error(err_str)
+                } else {
+                    // Unknown error — do not leak internal traces in external message
+                    error!("Error fetching URL {}: {}", params.url, err_str);
+                    let payload = build_error_payload(
+                        "ERR_FETCH_UNKNOWN",
+                        "An unknown error occurred while fetching the content",
+                        json!({
+                            "url": params.url,
+                            "hint": "Please try again later or provide a different URL."
+                        }),
+                    );
+                    CallToolResult::error(payload)
+                }
             }
         }
     }

--- a/src/tools/jina_reader_tool.rs
+++ b/src/tools/jina_reader_tool.rs
@@ -4,9 +4,10 @@ use serde_json::json;
 use tracing::{error, info};
 
 use crate::mcp::types::{CallToolResult, ToolAnnotations, ToolDefinition};
-use crate::utils::jina_reader::{JinaReaderService, JinaReaderParams as ServiceParams};
+use crate::utils::jina_reader::{JinaReaderParams as ServiceParams, JinaReaderService};
 
-pub static JINA_READER_TOOL_DEFINITION: Lazy<ToolDefinition> = Lazy::new(|| ToolDefinition {
+pub static JINA_READER_TOOL_DEFINITION: Lazy<ToolDefinition> = Lazy::new(|| {
+    ToolDefinition {
     name: "jina-reader".to_string(),
     description: "Retrieve LLM-friendly content from a single website URL using Jina r.reader API. Useful when you know the specific source of information.".to_string(),
     input_schema: json!({
@@ -64,6 +65,7 @@ pub static JINA_READER_TOOL_DEFINITION: Lazy<ToolDefinition> = Lazy::new(|| Tool
         read_only_hint: Some(true),
         open_world_hint: Some(true),
     }),
+}
 });
 
 #[derive(Debug, Deserialize)]
@@ -116,7 +118,8 @@ impl JinaReaderTool {
             Some(service) => service,
             None => {
                 return CallToolResult::error(
-                    "Jina Reader API key not configured. Set JINA_API_KEY environment variable.".to_string()
+                    "Jina Reader API key not configured. Set JINA_API_KEY environment variable."
+                        .to_string(),
                 );
             }
         };
@@ -168,12 +171,15 @@ impl JinaReaderTool {
 
                 // Build result with metadata
                 let mut result = format!("# {}", response.title.unwrap_or("Untitled".to_string()));
-                
+
                 if let Some(description) = response.description {
                     result.push_str(&format!("\n\n**Description:** {}\n", description));
                 }
-                
-                result.push_str(&format!("\n**URL:** {}\n\n", response.url.unwrap_or(params.url.clone())));
+
+                result.push_str(&format!(
+                    "\n**URL:** {}\n\n",
+                    response.url.unwrap_or(params.url.clone())
+                ));
                 result.push_str(&truncated_content);
 
                 // Add links summary if requested and available

--- a/src/utils/content_guard.rs
+++ b/src/utils/content_guard.rs
@@ -1,0 +1,154 @@
+use serde_json::{json, Value};
+
+/// Result of binary detection based on Content-Type and magic bytes
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BinaryDetection {
+    /// Content is considered binary; optional MIME is provided when known
+    Binary { content_type: Option<String> },
+    /// Content is considered textual (safe to decode as UTF-8)
+    Text,
+}
+
+/// Detects whether the content should be treated as binary using MIME and/or magic signatures in the head bytes.
+///
+/// content_type: Optional Content-Type value from response headers
+/// head: First bytes of the body (recommended ~512 bytes)
+pub fn detect_binary(content_type: Option<&str>, head: &[u8]) -> BinaryDetection {
+    // 1) Check MIME if available
+    if let Some(ct_raw) = content_type {
+        let ct = ct_raw.trim().to_ascii_lowercase();
+
+        // Extract type/subtype without parameters (e.g., `text/html; charset=utf-8` -> `text/html`)
+        let mime_main = ct.split(';').next().unwrap_or("").trim();
+
+        // Whitelist textual types explicitly considered safe
+        // Note: `text/*`, `application/json`, `application/xml`, `application/javascript`, `application/xhtml+xml`
+        let is_textual = mime_main.starts_with("text/")
+            || matches!(
+                mime_main,
+                "application/json"
+                    | "application/xml"
+                    | "application/javascript"
+                    | "application/xhtml+xml"
+                    | "application/x-www-form-urlencoded"
+            );
+
+        if !is_textual {
+            // Explicit binary types and families
+            let is_explicit_binary = mime_main.starts_with("image/")
+                || mime_main.starts_with("audio/")
+                || mime_main.starts_with("video/")
+                || mime_main.starts_with("font/")
+                || mime_main == "application/pdf"
+                || mime_main == "application/zip"
+                || mime_main == "application/gzip"
+                || mime_main == "application/octet-stream"
+                || mime_main.starts_with("application/x-")
+                || mime_main.starts_with("application/vnd.");
+
+            if is_explicit_binary {
+                return BinaryDetection::Binary {
+                    content_type: Some(mime_main.to_string()),
+                };
+            }
+        }
+
+        // If MIME confidently says it's textual, we can immediately return Text without peeking bytes
+        if is_textual {
+            return BinaryDetection::Text;
+        }
+        // Otherwise fall through to signature-based detection for extra safety
+    }
+
+    // 2) Signature-based detection on the first bytes
+    let h = head;
+
+    // Helper closures
+    let starts_with = |pat: &[u8]| h.len() >= pat.len() && &h[..pat.len()] == pat;
+    let contains_within = |pat: &[u8], limit: usize| {
+        let lim = limit.min(h.len());
+        h[..lim].windows(pat.len()).any(|w| w == pat)
+    };
+
+    // Common binary magic signatures
+    const PDF: &[u8] = b"%PDF-"; // PDF
+    const PNG: &[u8] = &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A]; // PNG
+    const JPEG: &[u8] = &[0xFF, 0xD8, 0xFF]; // JPEG
+    const GIF: &[u8] = b"GIF8"; // GIF87a/GIF89a
+    const RIFF: &[u8] = b"RIFF"; // RIFF container (WebP, WAV, AVI)
+    const WEBP: &[u8] = b"WEBP"; // WebP signature after RIFF
+    const ZIP: &[u8] = &[0x50, 0x4B, 0x03, 0x04]; // ZIP
+    const GZIP: &[u8] = &[0x1F, 0x8B]; // GZIP
+    const RAR: &[u8] = b"Rar!"; // RAR
+    const SEVEN_Z: &[u8] = &[0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C]; // 7z
+    const MP4_FTYP: &[u8] = b"ftyp"; // MP4 brands indicator
+
+    let is_binary_by_magic = starts_with(PDF)
+        || starts_with(PNG)
+        || starts_with(JPEG)
+        || starts_with(GIF)
+        || starts_with(ZIP)
+        || starts_with(GZIP)
+        || starts_with(RAR)
+        || starts_with(SEVEN_Z)
+        // RIFF...WEBP
+        || (starts_with(RIFF) && h.len() >= 12 && &h[8..12] == WEBP)
+        // MP4: `ftyp` often appears within first ~64 bytes
+        || contains_within(MP4_FTYP, 64);
+
+    if is_binary_by_magic {
+        return BinaryDetection::Binary { content_type: None };
+    }
+
+    BinaryDetection::Text
+}
+
+/// Safely truncates a UTF-8 string without breaking character boundaries.
+/// If `s` length exceeds `max`, returns a string cut at a valid char boundary and appends `suffix`.
+/// The resulting string length will be <= max whenever possible (suffix included). If `max` < suffix length,
+/// the function returns a safely cut string without suffix, not exceeding `max` bytes.
+pub fn safe_truncate_utf8(s: &str, max: usize, suffix: &str) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+
+    if max == 0 {
+        return String::new();
+    }
+
+    let suffix_len = suffix.len();
+    if max <= suffix_len {
+        // Not enough room for the suffix; just cut on a char boundary up to max
+        let mut end = max;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        return s[..end].to_string();
+    }
+
+    let mut end = max - suffix_len;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut result = String::with_capacity(end + suffix_len);
+    result.push_str(&s[..end]);
+    result.push_str(suffix);
+    result
+}
+
+/// Builds a standardized error payload string for tool errors.
+/// The resulting text is intended to be returned as a textual tool error body.
+/// First line: short human-readable message.
+/// Then a JSON object with fields: code, message, details.
+pub fn build_error_payload(code: &str, message: &str, details: Value) -> String {
+    let obj = json!({
+        "code": code,
+        "message": message,
+        "details": details,
+    });
+    let mut out = String::new();
+    out.push_str(message);
+    out.push('\n');
+    out.push_str(&obj.to_string());
+    out
+}

--- a/src/utils/duckduckgo_search.rs
+++ b/src/utils/duckduckgo_search.rs
@@ -6,12 +6,12 @@ use reqwest::Client;
 use scraper::{Html, Selector};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
+use tokio::sync::Mutex as AsyncMutex; // Async mutex for rate limiting queue
 use tracing::debug;
 use url::Url;
-use tokio::sync::Mutex as AsyncMutex; // Async mutex for rate limiting queue
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 // Constants
 const RESULTS_PER_PAGE: u32 = 10;

--- a/src/utils/jina_reader.rs
+++ b/src/utils/jina_reader.rs
@@ -80,8 +80,6 @@ pub struct JinaReaderParams {
     pub timeout: u32,
 }
 
-
-
 pub struct JinaReaderService {
     client: Client,
     api_key: String,
@@ -109,17 +107,38 @@ impl JinaReaderService {
     ) -> Result<JinaReaderResponse, JinaReaderError> {
         let request_body = JinaReaderRequest {
             url: url.to_string(),
-            with_links_summary: if params.with_links_summary { Some(true) } else { None },
-            with_images_summary: if params.with_images_summary { Some(true) } else { None },
-            with_generated_alt: if params.with_generated_alt { Some(true) } else { None },
-            return_format: if params.return_format != "markdown" { Some(params.return_format.clone()) } else { None },
+            with_links_summary: if params.with_links_summary {
+                Some(true)
+            } else {
+                None
+            },
+            with_images_summary: if params.with_images_summary {
+                Some(true)
+            } else {
+                None
+            },
+            with_generated_alt: if params.with_generated_alt {
+                Some(true)
+            } else {
+                None
+            },
+            return_format: if params.return_format != "markdown" {
+                Some(params.return_format.clone())
+            } else {
+                None
+            },
             no_cache: if params.no_cache { Some(true) } else { None },
-            timeout: if params.timeout != 10 { Some(params.timeout) } else { None },
+            timeout: if params.timeout != 10 {
+                Some(params.timeout)
+            } else {
+                None
+            },
         };
 
         debug!("Sending request to Jina Reader API: {:?}", request_body);
 
-        let mut request_builder = self.client
+        let mut request_builder = self
+            .client
             .post(&self.endpoint)
             .header(header::CONTENT_TYPE, "application/json")
             .header(header::ACCEPT, "application/json")
@@ -155,9 +174,9 @@ impl JinaReaderService {
             Ok(response) => {
                 let response_text = response.text().await?;
                 debug!("Received response from Jina Reader API: {}", response_text);
-                
+
                 let api_response = serde_json::from_str::<JinaReaderApiResponse>(&response_text)?;
-                
+
                 // Convert to the expected response format
                 let reader_response = JinaReaderResponse {
                     url: api_response.data.url,
@@ -167,9 +186,9 @@ impl JinaReaderService {
                     links: api_response.data.links,
                     images: api_response.data.images,
                 };
-                
+
                 Ok(reader_response)
-            },
+            }
             Err(err) => {
                 if let Some(status) = err.status() {
                     error!("Jina Reader API error: Status {}", status);

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod content_guard;
 pub mod duckduckgo_search;
 pub mod google_search;
 pub mod jina_reader;


### PR DESCRIPTION
- Add warning logs for unsupported binary content fetch attempts.
- Implement standardized error payload for binary refusal cases.
- Improve error handling for unknown fetch errors to avoid leaking internal traces.