### PR TITLE
Feat/pdf-extract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-getweb"
-version = "1.3.1"
+version = "1.4.0"
 edition = "2021"
 description = "A Model Context Protocol server for web search using DuckDuckGo, Google Search, and Felo AI"
 license = "MIT"
@@ -21,7 +21,7 @@ tokio = { version = "1.0", features = ["full"] }
 reqwest = { version = "0.12", features = ["json", "stream", "native-tls-vendored", "brotli"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-scraper = "0.20"
+scraper = "0.24.0"
 url = "2.5"
 uuid = { version = "1.0", features = ["v4"] }
 anyhow = "1.0"
@@ -35,6 +35,7 @@ once_cell = "1.0"
 rand = "0.8"
 urlencoding = "2.1"
 tokio-util = { version = "0.7", features = ["codec"] }
-thiserror = "1.0"
+thiserror = "2.0.17"
 html5ever = "0.26"
 markup5ever_rcdom = "0.2"
+pdf-extract = "0.10.0"

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,3 +3,4 @@ pub mod duckduckgo_search;
 pub mod google_search;
 pub mod jina_reader;
 pub mod search_felo;
+pub mod pdf;

--- a/src/utils/pdf.rs
+++ b/src/utils/pdf.rs
@@ -1,0 +1,20 @@
+// Minimal PDF utilities used across fetch-url and url-fetch flows.
+// Always keep this module small and dependency-light.
+
+use anyhow::Context;
+
+/// Extracts text from a PDF stored fully in memory.
+/// This is a thin wrapper over the `pdf-extract` crate API.
+pub fn extract_text_from_pdf_mem(bytes: &[u8]) -> anyhow::Result<String> {
+    let text = pdf_extract::extract_text_from_mem(bytes)
+        .context("failed to extract text from PDF bytes using pdf-extract")?;
+    Ok(text)
+}
+
+/// Returns true if given content-type or head indicates a PDF file.
+/// - Content-Type: application/pdf (case-insensitive, substring match)
+/// - Magic bytes: %PDF-
+pub fn is_pdf(content_type: Option<&str>, head: &[u8]) -> bool {
+    let ct = content_type.unwrap_or("").to_ascii_lowercase();
+    ct.contains("application/pdf") || head.starts_with(b"%PDF-")
+}


### PR DESCRIPTION
- Introduce `extract_text_from_pdf_mem` and `is_pdf` functions for PDF processing.
- Implement early size checks for PDFs in `fetch_url_content` to prevent oversized files from being processed.
- Enhance logging for PDF extraction and error handling.
- Update `mod.rs` to include the new PDF module.